### PR TITLE
Correct use of non-English word "innecesary"

### DIFF
--- a/doc/articles/thymeleaf3migration.html
+++ b/doc/articles/thymeleaf3migration.html
@@ -172,7 +172,7 @@
 <p>Sometimes it is handy to be able to output data without using extra tags or attributes, as in:</p>
 <pre class="html"><code>    &lt;p&gt;This product is called [[${product.name}]] and it&#39;s great!&lt;/p&gt;</code></pre>
 <p>This capability, called <em>inlining</em> has been greatly improved and is now much better supported in Thymeleaf 3. See <a href="https://github.com/thymeleaf/thymeleaf/issues/394">Inlined output expressions</a> for details.</p>
-<p>The existing inlining mechanism also matches the new template modes and, indeed, make innecesary the <code>th:inline=&quot;text&quot;</code> attribute because inlining now exists in <code>HTML</code> mode itself. Take a look at the discussion on <a href="https://github.com/thymeleaf/thymeleaf/issues/396">Refactoring of the inlining mechanism</a></p>
+<p>The existing inlining mechanism also matches the new template modes and, indeed, makes the <code>th:inline=&quot;text&quot;</code> attribute unnecessary, because inlining now exists in <code>HTML</code> mode itself. Take a look at the discussion on <a href="https://github.com/thymeleaf/thymeleaf/issues/396">Refactoring of the inlining mechanism</a></p>
 </section>
 </section>
 <section id="performance-improvements" class="level2">


### PR DESCRIPTION
Also, reword that sentence to flow a bit more naturally.