### PR TITLE
Remove redundant preposition 'to'.

### DIFF
--- a/doc/tutorials/3.0/usingthymeleaf.md
+++ b/doc/tutorials/3.0/usingthymeleaf.md
@@ -3452,7 +3452,7 @@ The result will be HTML-escaped:
 ```
 
 Note that **text inlining is active by default** in the body of every tag in our markup –not the tags
-themselves–, so there is nothing we need to do to to enable it.
+themselves–, so there is nothing we need to do to enable it.
 
 
 ###Inlining vs natural templates


### PR DESCRIPTION
Remove redundant preposition 'to' in [12.1 Expression inlining](https://github.com/thymeleaf/thymeleaf.github.com/blob/master/doc/tutorials/3.0/usingthymeleaf.md#121-expression-inlining).