### PR TITLE
Travis-CI website URL update: www.travis-ci.com

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -432,7 +432,7 @@
 					repository contained more than 1,300 test files, adding up to more
 					than 37,000 lines of testing code.</p>
 
-					<p>Besides, we use <a href="https://travis-ci.org/">Travis CI</a> for
+					<p>Besides, we use <a href="https://travis-ci.com/">Travis CI</a> for
 					continuous integration, thanks to what every release is published
 					after being tested in no-Spring, Spring 3.0, Spring 3.1, Spring 3.2
 					and Spring 4.0 environments, with Java 6, 7 and 8 (unfortunately


### PR DESCRIPTION
They're migrating to a new domain.